### PR TITLE
Fix torch, sacrebleu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cd access
 pip install -e .
 pip install --force-reinstall easse@git+git://github.com/feralvam/easse.git@580ec953e4742c3ae806cc85d867c16e9f584505
 pip install --force-reinstall fairseq@git+https://github.com/louismartin/fairseq.git@controllable-sentence-simplification
+
+pip install torch==1.2
+pip install sacrebleu==1.3.7
 ```
 
 ### How to use


### PR DESCRIPTION
I'd have updated the requirements.txt, but it seems the `torch` version there gets overwritten by other packages which have it as a dependency. To prevent circular dependency issues it's easier to install the required package versions separately.